### PR TITLE
Add web-validated ESP32 DevKit shortlist and update docs/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # RTC_BL_PHONE
-esp32 bluetooth audio to rtc phone
+
+Projet PlatformIO ESP32 pour recycler un téléphone RTC ancien (combiné, clavier, hook).
+
+## Démarrage rapide
+1. Ouvrir le dossier dans PlatformIO.
+2. Compiler et flasher l'environnement `esp32dev`.
+3. Ouvrir le moniteur série à 115200 bauds.
+
+## Choix de cartes ESP32
+Voir `docs/solutions_rtc_phone_esp32.md` pour la shortlist des DevKit utilisables (ESP32-DevKitC, ESP32-S3-DevKitC-1, NodeMCU-32S, LOLIN32) et les liens de référence web.
+
+## Contenu
+- `platformio.ini`: configuration initiale du projet.
+- `src/main.cpp`: prototype minimal (détection décroché/raccroché).
+- `docs/solutions_rtc_phone_esp32.md`: comparaison des meilleures architectures + sélection de DevKit ESP32 recommandés.

--- a/docs/solutions_rtc_phone_esp32.md
+++ b/docs/solutions_rtc_phone_esp32.md
@@ -1,0 +1,116 @@
+# Solutions recommandées: ESP32 + téléphone RTC ancien
+
+## Objectif
+Créer un projet PlatformIO sur ESP32 pour réutiliser un ancien téléphone analogique RTC (combiné, clavier, crochet) avec une architecture moderne.
+
+## Contraintes importantes
+- **Ne jamais connecter directement** l'ESP32 à une ligne téléphonique publique (PSTN) sans isolation/éléments homologués.
+- Les tensions de sonnerie peuvent être élevées; prévoir isolation galvanique si interface ligne 2 fils.
+- La qualité audio dépend fortement du front-end analogique (adaptation d'impédance, gain, anti-larsen).
+
+## Option A — Réutiliser uniquement le combiné + clavier (recommandé MVP)
+### Principe
+- Débrancher l'électronique ligne d'origine.
+- Lire en hard:
+  - hook switch (décroché/raccroché)
+  - clavier (matrice)
+- Audio:
+  - micro du combiné vers préampli + ADC/codec I2S
+  - écouteur via DAC/codec + ampli
+
+### Avantages
+- La plus simple pour un premier prototype.
+- Sécurité électrique plus facile à maîtriser.
+- Excellente maîtrise logicielle côté ESP32 (Bluetooth, Wi-Fi, SIP, intercom local).
+
+### Inconvénients
+- Nécessite un peu d'analogique audio (préamp, filtre, gain).
+- Le clavier ancien peut demander reverse engineering.
+
+## Option B — Interface 2 fils complète type "ligne RTC privée" (SLIC/DAA)
+### Principe
+- Conserver le téléphone quasiment tel quel (port RJ11/2 fils).
+- Générer alimentation de boucle, tonalité, éventuellement sonnerie via circuit spécialisé (SLIC).
+
+### Avantages
+- Expérience "téléphone d'origine" la plus fidèle.
+- Compatible avec plusieurs postes analogiques.
+
+### Inconvénients
+- Plus complexe et coûteux.
+- Design analogique + sécurité plus exigeants.
+- Debug plus long.
+
+## Option C — Passerelle hybride (ATA/FXS externe + ESP32 contrôle)
+### Principe
+- L'audio et la boucle téléphonique sont gérés par un matériel externe (ATA/box FXS).
+- ESP32 gère logique applicative (boutons, scénario d'appel, domotique, BLE/Wi-Fi).
+
+### Avantages
+- Déploiement rapide avec qualité voix stable.
+- Risque analogique réduit.
+
+### Inconvénients
+- Dépendance à un boîtier externe.
+- Moins "DIY full stack".
+
+## Dev kits ESP32 utilisables (vérifiés web)
+> Recherche croisée faite sur la doc officielle Espressif (`esp-dev-kits`) et la liste des cartes PlatformIO (`espressif32`).
+
+### Recommandés pour TON projet (RTC + combiné + clavier + audio)
+1. **ESP32-DevKitC (WROOM-32)**
+   - Très compatible avec exemples existants.
+   - Wi-Fi + Bluetooth Classic/BLE utile si tu vises audio BT/HFP plus tard.
+   - Mapping PlatformIO simple: `board = esp32dev`.
+
+2. **ESP32-S3-DevKitC-1**
+   - Plus récent, bon support I/O et USB natif.
+   - Très bon choix pour version long terme (UI, USB CDC, plus de marge CPU/RAM selon variantes).
+   - Mapping PlatformIO: `board = esp32-s3-devkitc-1`.
+
+3. **NodeMCU-32S / LOLIN32**
+   - Faciles à trouver et souvent moins chers.
+   - Bons pour prototypage hook + clavier + logique de numérotation.
+   - Mapping PlatformIO: `board = nodemcu-32s` ou `board = lolin32`.
+
+### Utilisables mais moins adaptés à ton besoin immédiat
+- **ESP32-C3-DevKitC-02**
+  - Très bien pour projets IoT BLE/Wi-Fi.
+  - Mais pas de Bluetooth Classic, donc moins idéal si objectif audio BT "téléphone" avancé.
+
+## Recommandation pratique
+1. **Phase 1 (MVP): Option A + ESP32-DevKitC**
+   - Hook + clavier + audio local simple.
+   - Validation UX (décroché, composition, feedback audio).
+2. **Phase 2:** ajout Bluetooth/Wi-Fi (SIP/WebRTC passerelle).
+3. **Phase 3:** si besoin d'un vrai port 2 fils: migration vers Option B.
+
+## Matériel conseillé (MVP)
+- ESP32-WROOM / ESP32-S3.
+- Codec audio I2S simple (ou carte audio ESP32 dédiée).
+- Petit ampli casque/écouteur + préampli micro électret/carbone selon combiné.
+- Optocoupleur ou transistors pour lecture fiable hook/clavier si tensions atypiques.
+- Alimentation propre 5V + 3.3V, masse analogique soignée.
+
+## Notes logiciel PlatformIO
+- Démarrer avec un squelette Arduino + machine d'états:
+  - `IDLE` (raccroché)
+  - `OFF_HOOK`
+  - `DIALING`
+  - `IN_CALL`
+- Ajouter journal série détaillé dès le début.
+- Écrire des tests de mapping clavier (table de correspondance).
+
+## Sources web utiles
+- Espressif DevKitC: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32/esp32-devkitc/index.html
+- Espressif S3 DevKitC-1: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html
+- PlatformIO `esp32dev`: https://docs.platformio.org/en/latest/boards/espressif32/esp32dev.html
+- PlatformIO `esp32-s3-devkitc-1`: https://docs.platformio.org/en/latest/boards/espressif32/esp32-s3-devkitc-1.html
+- PlatformIO `nodemcu-32s`: https://docs.platformio.org/en/latest/boards/espressif32/nodemcu-32s.html
+- PlatformIO `lolin32`: https://docs.platformio.org/en/latest/boards/espressif32/lolin32.html
+- PlatformIO `esp32-c3-devkitc-02`: https://docs.platformio.org/en/latest/boards/espressif32/esp32-c3-devkitc-02.html
+
+## Décision proposée
+Pour ton besoin immédiat (PLIP / combiné + clavier en hard), la **meilleure balance risque/temps** est:
+- **Option A en premier** avec **ESP32-DevKitC**.
+- Puis extension progressive vers ESP32-S3 ou interface ligne complète si nécessaire.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,12 @@
+[platformio]
+default_envs = esp32dev
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+build_flags =
+  -DCORE_DEBUG_LEVEL=1
+lib_deps =
+  bblanchon/ArduinoJson@^7.0.4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,32 @@
+#include <Arduino.h>
+
+// Prototype minimal pour valider le câblage d'un téléphone RTC recyclé.
+// - Hook switch: détection décroché/raccroché
+// - Clavier: lecture en matrice (adaptateur nécessaire selon le modèle)
+// - Audio: à implémenter ensuite via codec I2S / interface analogique dédiée
+
+constexpr uint8_t PIN_HOOK = 27;   // Adapter selon le câblage réel
+constexpr uint8_t PIN_LED  = 2;    // LED status carte
+
+bool offHook = false;
+
+void setup() {
+  Serial.begin(115200);
+  pinMode(PIN_HOOK, INPUT_PULLUP);
+  pinMode(PIN_LED, OUTPUT);
+  digitalWrite(PIN_LED, LOW);
+
+  Serial.println("\n[RTC_PHONE] Boot OK");
+  Serial.println("[RTC_PHONE] MVP: hook + logique d'etat");
+}
+
+void loop() {
+  bool hookState = digitalRead(PIN_HOOK) == LOW;  // LOW = décroché (exemple)
+  if (hookState != offHook) {
+    offHook = hookState;
+    digitalWrite(PIN_LED, offHook ? HIGH : LOW);
+    Serial.printf("[RTC_PHONE] Etat combine: %s\n", offHook ? "DECROCHE" : "RACCROCHE");
+  }
+
+  delay(20);
+}


### PR DESCRIPTION
### Motivation
- Provide concrete, web-validated recommendations for which ESP32 DevKit boards are best suited for the RTC phone MVP (combiné + clavier + audio) to make hardware selection easier.
- Surface PlatformIO board IDs and official references so users can start a project quickly and pick an appropriate dev kit for later audio/Bluetooth work.

### Description
- Added `docs/solutions_rtc_phone_esp32.md` with a short-listed set of recommended dev kits (ESP32-DevKitC `esp32dev`, ESP32-S3-DevKitC-1 `esp32-s3-devkitc-1`, NodeMCU-32S `nodemcu-32s`, LOLIN32 `lolin32`), a note about ESP32-C3 suitability, and links to Espressif / PlatformIO docs.
- Updated `README.md` to include quickstart steps and a pointer to the new dev kit selection guidance.
- Kept existing PlatformIO skeleton (`platformio.ini`) and minimal prototype firmware (`src/main.cpp`) from the project scaffold to preserve the working starting point for the MVP.

### Testing
- Verified referenced Espressif and PlatformIO documentation URLs returned HTTP 200 using `curl` checks, and all listed links responded with status `200` (success). 
- Ran `git` operations to stage and commit the changes and verified the commit completed successfully. 
- Attempted a PlatformIO build was not executed in this environment because the `pio` CLI is not installed, so no local build was run (external `pio` build not tested here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1c841f888331bc152e21bf583a5b)