### PR TITLE
[codex] webui coverage for bluetooth and config backend routes

### DIFF
--- a/data/webui/index.html
+++ b/data/webui/index.html
@@ -32,6 +32,29 @@
         <button id="refreshConfigBtn">Rafraîchir configuration</button>
       </div>
       <pre id="configJson"></pre>
+      <div class="grid2">
+        <div>
+          <h3>Audio config (JSON)</h3>
+          <textarea id="audioConfigInput" rows="8" placeholder='{"volume":80}'></textarea>
+          <div class="inline-actions">
+            <button id="applyAudioConfigBtn">Appliquer audio</button>
+          </div>
+        </div>
+        <div>
+          <h3>MQTT config (JSON)</h3>
+          <textarea id="mqttConfigInput" rows="8" placeholder='{"enabled":false}'></textarea>
+          <div class="inline-actions">
+            <button id="applyMqttConfigBtn">Appliquer MQTT</button>
+          </div>
+        </div>
+        <div>
+          <h3>Pins config (JSON)</h3>
+          <textarea id="pinsConfigInput" rows="8" placeholder='{"slic":{"line":23}}'></textarea>
+          <div class="inline-actions">
+            <button id="applyPinsConfigBtn">Appliquer pins</button>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section id="networkSection">
@@ -85,6 +108,21 @@
           </div>
           <pre id="espnowJson"></pre>
           <pre id="espnowPeersJson"></pre>
+        </div>
+
+        <div>
+          <h3>Bluetooth</h3>
+          <form id="btHfpConnectForm">
+            <input type="text" id="btHfpAddr" placeholder="MAC téléphone HFP (AA:BB:CC:DD:EE:FF)">
+            <button type="submit">HFP Connect</button>
+          </form>
+          <div class="inline-actions">
+            <button id="btHfpDisconnectBtn">HFP Disconnect</button>
+            <button id="btBleStartBtn">BLE Start</button>
+            <button id="btBleStopBtn">BLE Stop</button>
+            <button id="btRefreshBtn">Rafraîchir BT</button>
+          </div>
+          <pre id="btJson"></pre>
         </div>
       </div>
     </section>

--- a/data/webui/script.js
+++ b/data/webui/script.js
@@ -51,6 +51,14 @@ function jsonHeaders() {
   return { "Content-Type": "application/json" };
 }
 
+function parseJsonInput(id) {
+  const raw = document.getElementById(id).value.trim();
+  if (!raw) {
+    return {};
+  }
+  return JSON.parse(raw);
+}
+
 function parsePayloadValue(rawPayload) {
   const trimmed = rawPayload.trim();
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
@@ -90,6 +98,18 @@ async function refreshConfig() {
       requestJson("/api/config/mqtt"),
     ]);
     setJson("configJson", { pins, audio, mqtt });
+    const audioInput = document.getElementById("audioConfigInput");
+    const mqttInput = document.getElementById("mqttConfigInput");
+    const pinsInput = document.getElementById("pinsConfigInput");
+    if (audioInput) {
+      audioInput.value = JSON.stringify(audio, null, 2);
+    }
+    if (mqttInput) {
+      mqttInput.value = JSON.stringify(mqtt.config || mqtt, null, 2);
+    }
+    if (pinsInput) {
+      pinsInput.value = JSON.stringify(pins, null, 2);
+    }
   } catch (error) {
     setJson("configJson", { error: error.message });
   }
@@ -116,6 +136,15 @@ async function refreshNetwork() {
   }
 }
 
+async function refreshBluetooth() {
+  try {
+    const bt = await requestJson("/api/bluetooth");
+    setJson("btJson", bt);
+  } catch (error) {
+    setJson("btJson", { error: error.message });
+  }
+}
+
 async function sendControl(action) {
   const result = await requestJson("/api/control", {
     method: "POST",
@@ -137,6 +166,52 @@ function bindEvents() {
   });
   document.getElementById("refreshConfigBtn").addEventListener("click", refreshConfig);
   document.getElementById("espnowRefreshBtn").addEventListener("click", refreshNetwork);
+  document.getElementById("btRefreshBtn").addEventListener("click", refreshBluetooth);
+
+  document.getElementById("applyAudioConfigBtn").addEventListener("click", async () => {
+    try {
+      const payload = parseJsonInput("audioConfigInput");
+      const result = await requestJson("/api/config/audio", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify(payload),
+      });
+      setJson("actionResult", result);
+      await Promise.all([refreshConfig(), refreshStatus()]);
+    } catch (error) {
+      setJson("actionResult", { error: error.message });
+    }
+  });
+
+  document.getElementById("applyMqttConfigBtn").addEventListener("click", async () => {
+    try {
+      const payload = parseJsonInput("mqttConfigInput");
+      const result = await requestJson("/api/config/mqtt", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify(payload),
+      });
+      setJson("actionResult", result);
+      await Promise.all([refreshConfig(), refreshNetwork(), refreshStatus()]);
+    } catch (error) {
+      setJson("actionResult", { error: error.message });
+    }
+  });
+
+  document.getElementById("applyPinsConfigBtn").addEventListener("click", async () => {
+    try {
+      const payload = parseJsonInput("pinsConfigInput");
+      const result = await requestJson("/api/config/pins", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify(payload),
+      });
+      setJson("actionResult", result);
+      await Promise.all([refreshConfig(), refreshStatus()]);
+    } catch (error) {
+      setJson("actionResult", { error: error.message });
+    }
+  });
 
   document.getElementById("wifiConnectForm").addEventListener("submit", async (event) => {
     event.preventDefault();
@@ -319,6 +394,64 @@ function bindEvents() {
     }
   });
 
+  document.getElementById("btHfpConnectForm").addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const addr = document.getElementById("btHfpAddr").value.trim();
+    try {
+      const result = await requestJson("/api/bluetooth/hfp/connect", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ addr }),
+      });
+      setJson("actionResult", result);
+      await Promise.all([refreshBluetooth(), refreshStatus()]);
+    } catch (error) {
+      setJson("actionResult", { error: error.message });
+    }
+  });
+
+  document.getElementById("btHfpDisconnectBtn").addEventListener("click", async () => {
+    try {
+      const result = await requestJson("/api/bluetooth/hfp/disconnect", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: "{}",
+      });
+      setJson("actionResult", result);
+      await Promise.all([refreshBluetooth(), refreshStatus()]);
+    } catch (error) {
+      setJson("actionResult", { error: error.message });
+    }
+  });
+
+  document.getElementById("btBleStartBtn").addEventListener("click", async () => {
+    try {
+      const result = await requestJson("/api/bluetooth/ble/start", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: "{}",
+      });
+      setJson("actionResult", result);
+      await Promise.all([refreshBluetooth(), refreshStatus()]);
+    } catch (error) {
+      setJson("actionResult", { error: error.message });
+    }
+  });
+
+  document.getElementById("btBleStopBtn").addEventListener("click", async () => {
+    try {
+      const result = await requestJson("/api/bluetooth/ble/stop", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: "{}",
+      });
+      setJson("actionResult", result);
+      await Promise.all([refreshBluetooth(), refreshStatus()]);
+    } catch (error) {
+      setJson("actionResult", { error: error.message });
+    }
+  });
+
   document.querySelectorAll("#controlSection button[data-action]").forEach((button) => {
     button.addEventListener("click", async () => {
       try {
@@ -342,6 +475,6 @@ function bindEvents() {
 
 document.addEventListener("DOMContentLoaded", async () => {
   bindEvents();
-  await Promise.all([refreshStatus(), refreshConfig(), refreshNetwork()]);
+  await Promise.all([refreshStatus(), refreshConfig(), refreshNetwork(), refreshBluetooth()]);
   showSection("dashboard");
 });


### PR DESCRIPTION
## Scope
Implements RTC issue #10 by extending WebUI coverage for backend routes that were not exposed to operators.

## Changes
- `data/webui/index.html`
  - Added Bluetooth panel with actions:
    - GET `/api/bluetooth`
    - POST `/api/bluetooth/hfp/connect`
    - POST `/api/bluetooth/hfp/disconnect`
    - POST `/api/bluetooth/ble/start`
    - POST `/api/bluetooth/ble/stop`
  - Added JSON editors in Configuration section for:
    - POST `/api/config/audio`
    - POST `/api/config/mqtt`
    - POST `/api/config/pins`
- `data/webui/script.js`
  - Added handlers for Bluetooth refresh/actions.
  - Added JSON parsing/apply handlers for audio/mqtt/pins config posts.
  - Config refresh now pre-fills JSON editors from current backend values.

## Validation
- `python3 scripts/check_web_route_parity.py --frontend data/webui/script.js --backend src/web/WebServerManager.cpp` -> PASS
- `python3 -m unittest scripts.test_check_web_route_parity` -> PASS
- `platformio run -e esp32dev` -> PASS

## Related
- Closes #10
- Spec baseline: #16
